### PR TITLE
Use cross-fetch to avoid missing "Response.blob()"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
-require('isomorphic-fetch')
+const crossFetch = require("cross-fetch");
+global.fetch = crossFetch;
+global.Response = crossFetch.Response;
+global.Headers = crossFetch.Headers;
+global.Request = crossFetch.Request;
 
 if (!Promise) {
   Promise = require('promise-polyfill');


### PR DESCRIPTION
isomorphic-fetch hasn't been updated in ages, cross-fetch seems like a good alternative